### PR TITLE
Resolve nullability warnings

### DIFF
--- a/JEKScrollableSectionCollectionViewLayout.h
+++ b/JEKScrollableSectionCollectionViewLayout.h
@@ -6,6 +6,8 @@
 //  Copyright © 2018 Joel Ekström. All rights reserved.
 //
 
+NS_ASSUME_NONNULL_BEGIN
+
 #import <UIKit/UIKit.h>
 
 @class JEKScrollViewConfiguration;
@@ -67,3 +69,6 @@ extern NSString * const JEKCollectionElementKindSectionBackground;
 - (void)collectionView:(UICollectionView *)collectionView layout:(JEKScrollableSectionCollectionViewLayout *)layout sectionWillBeginDecelerating:(NSUInteger)section;
 - (void)collectionView:(UICollectionView *)collectionView layout:(JEKScrollableSectionCollectionViewLayout *)layout sectionDidEndDecelerating:(NSUInteger)section;
 @end
+
+NS_ASSUME_NONNULL_END
+ 


### PR DESCRIPTION
Since there is already a nullability annotation in this header (on the declaration of `-collectionView:layout:scrollViewConfigurationForSection:`), the compiler assumes that the header has been audited for nullability. However, most of the parameters were not marked as audited, which resulted in lots of compiler warnings everywhere this was imported.

With this change, all the warnings go away.

This change does assume that it is invalid to set `defaultScrollViewConfiguration = nil`. If there are cases where that should be allowed, then it would also need to be marked `nullable`, but I don't think that's actually a supported configuration.