### PR TITLE
Add proper support for `scrollToItemAtIndexPath:scrollPosition:animated`

### DIFF
--- a/JEKScrollableSectionCollectionViewLayout.h
+++ b/JEKScrollableSectionCollectionViewLayout.h
@@ -35,6 +35,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL showsSectionBackgrounds;
 extern NSString * const JEKCollectionElementKindSectionBackground;
 
+/**
+ Allows you to programmatically scroll a section.
+ */
+- (void)setHorizontalOffset:(CGFloat)offset forSectionAtIndex:(NSUInteger)index animated:(BOOL)animated;
+
 @end
 
 @interface JEKScrollViewConfiguration : NSObject

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ and you have to set the measurements in code. Check the example project for a fu
 - Properly supports inserts/deletes/moves (even between different sections)
   - ... since it does not create multiple `UICollectionView`s like this problem is normally solved
 - (almost) drop in replacement for `UICollectionViewFlowLayout`
-- A simple layout object - doesn't need to subclass or modify `UICollectionView` in any way
+- A simple layout object - doesn't need to subclass `UICollectionView`
   - ... leading to efficient reuse of cells and support for prefetching
 - Section background views (as optional supplementary views)
 


### PR DESCRIPTION
Handling correct scrolling to items required special handling in this
class, since UICollectionView does not expect layouts to have items
outside the scrollable bounds. It was solved by swizzling the method
and forwarding it to the layout (if the layout is the correct class).

Also adds a new public API:
`- (void)setHorizontalOffset:(CGFloat)offset forSectionAtIndex:(NSUInteger)index animated:(BOOL)animated;`

This might improve AppleTV support, hopefully fixing the problem
described in #17