### PR TITLE
Update JEKScrollableSectionCollectionViewLayout.h

### DIFF
--- a/JEKScrollableSectionCollectionViewLayout.h
+++ b/JEKScrollableSectionCollectionViewLayout.h
@@ -18,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) CGSize itemSize;
 @property (nonatomic) CGSize headerReferenceSize;
 @property (nonatomic) CGSize footerReferenceSize;
+@property (nonatomic) CGSize estimatedItemSize;
 @property (nonatomic) UIEdgeInsets sectionInset;
 
 /**


### PR DESCRIPTION
Error [<JEKScrollableSectionCollectionViewLayout 0x101d096f0> setValue:forUndefinedKey:]: this class is not key value coding-compliant for the key estimatedItemSize.

estimatedItemSize appears to be part of uicollectionviewflowlayout (https://developer.apple.com/documentation/uikit/uicollectionviewflowlayout?language=objc), this seems to cause a problem with the nib, at least for new projects.

I solved the problem by adding `@property (nonatomic) CGSize estimatedItemSize;` to JEKScrollableSectionCollectionViewLayout.h